### PR TITLE
Parent / child process ids

### DIFF
--- a/migrations/2019_04_02_101408_add_parent_id_to_table.php
+++ b/migrations/2019_04_02_101408_add_parent_id_to_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddParentIdToTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(config('process-stamps.table'), function (Blueprint $table) {
+            $table->unsignedInteger('parent_id')->nullable()->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table(config('process-stamps.table'), function (Blueprint $table) {
+            $table->dropColumn('parent_id');
+        });
+    }
+}

--- a/migrations/2019_04_02_101408_add_parent_id_to_table.php
+++ b/migrations/2019_04_02_101408_add_parent_id_to_table.php
@@ -14,7 +14,11 @@ class AddParentIdToTable extends Migration
     public function up()
     {
         Schema::table(config('process-stamps.table'), function (Blueprint $table) {
-            $table->unsignedInteger('parent_id')->nullable()->index();
+            $table->unsignedInteger('parent_id')->nullable()->index()->after('hash');
+
+            $table->foreign('parent_id')
+                ->references(config('process-stamps.columns.primary_key'))
+                ->on(config('process-stamps.table'));
         });
     }
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,5 +23,6 @@
         <env name="APP_NAME" value="testsite" />
         <env name="DB_CONNECTION" value="sqlite" />
         <env name="DB_DATABASE" value=":memory:" />
+        <env name="DB_FOREIGN_KEYS" value="true" />
     </php>
 </phpunit>

--- a/src/ProcessStamp.php
+++ b/src/ProcessStamp.php
@@ -7,7 +7,12 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ProcessStamp extends Model
 {
-    public $fillable = ['hash', 'name', 'type'];
+    public $fillable = [
+        'hash',
+        'name',
+        'type',
+        'parent_id',
+    ];
 
     /**
      * Override the primary key name to use the config.

--- a/src/ProcessStamp.php
+++ b/src/ProcessStamp.php
@@ -3,6 +3,7 @@
 namespace OrisIntel\ProcessStamps;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ProcessStamp extends Model
 {
@@ -55,5 +56,15 @@ class ProcessStamp extends Model
     public static function makeProcessHash(array $process) : string
     {
         return sha1($process['type'].'-'.$process['name']);
+    }
+
+    /**
+     * Get the parent of the command, if there is one.
+     *
+     * @return BelongsTo|null
+     */
+    public function parent() : ?BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
     }
 }

--- a/src/ProcessStamp.php
+++ b/src/ProcessStamp.php
@@ -127,6 +127,12 @@ class ProcessStamp extends Model
         $parent_name = null;
         $type = $type ?? static::getType();
 
+        /*
+         * KEEP THIS SHITTY. For now.
+         *
+         * This accesses $_SERVER directly as we can't count on the Laravel Request::server() object existing
+         * for applications with legacy code outside of the Laravel request lifecycle.
+         */
         switch ($type) {
             case 'url':
                 $name = $raw_process ?? $_SERVER['REQUEST_URI'];

--- a/src/ProcessStamp.php
+++ b/src/ProcessStamp.php
@@ -190,7 +190,7 @@ class ProcessStamp extends Model
     public static function getParentArtisan(string $command) : ?string
     {
         $command = trim($command);
-        if(strpos($command, ' --')) {
+        if (strpos($command, ' --')) {
             return explode(' --', $command, 2)[0];
         }
 

--- a/src/ProcessStamp.php
+++ b/src/ProcessStamp.php
@@ -53,13 +53,13 @@ class ProcessStamp extends Model
         }
 
         $parent = null;
-        if(!empty($process['parent_name'])) {
+        if (! empty($process['parent_name'])) {
             $parent = static::firstOrCreateByProcess(static::getProcessName($process['type'], $process['parent_name']));
         }
 
         return static::firstOrCreate(['hash' => $hash], [
-            'name' => trim($process['name']),
-            'type' => $process['type'],
+            'name'      => trim($process['name']),
+            'type'      => $process['type'],
             'parent_id' => optional($parent)->getKey(),
         ]);
     }
@@ -94,7 +94,6 @@ class ProcessStamp extends Model
         return $this->hasMany(self::class, 'parent_id');
     }
 
-
     /**
      * @return string
      */
@@ -120,6 +119,7 @@ class ProcessStamp extends Model
      *
      * @param string|null $type
      * @param string|null $raw_process
+     *
      * @return array
      */
     public static function getProcessName(?string $type = null, ?string $raw_process = null) : array
@@ -127,7 +127,7 @@ class ProcessStamp extends Model
         $parent_name = null;
         $type = $type ?? static::getType();
 
-        switch($type) {
+        switch ($type) {
             case 'url':
                 $name = $raw_process ?? $_SERVER['REQUEST_URI'];
                 $parent_name = static::getParentUrl($name);
@@ -169,14 +169,16 @@ class ProcessStamp extends Model
 
     /**
      * @param string $url
+     *
      * @return string|null
      */
     public static function getParentUrl(string $url) : ?string
     {
         if (strpos($stripped = trim($url, '/'), '/')) {
-            $parts = preg_split( "/(\/|\?)/", $stripped);
-            if(!empty($parts) && count($parts) > 1) {
+            $parts = preg_split("/(\/|\?)/", $stripped);
+            if (! empty($parts) && count($parts) > 1) {
                 array_pop($parts);
+
                 return '/'.implode('/', $parts);
             }
         }

--- a/src/ProcessStampable.php
+++ b/src/ProcessStampable.php
@@ -3,7 +3,6 @@
 namespace OrisIntel\ProcessStamps;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Support\Facades\Cache;
 
 trait ProcessStampable
 {

--- a/src/ProcessStampable.php
+++ b/src/ProcessStampable.php
@@ -13,12 +13,12 @@ trait ProcessStampable
     public static function bootProcessStampable() : void
     {
         static::creating(function ($model) {
-            $model->{static::getProcessCreatedColumnName()} = static::getProcessId();
-            $model->{static::getProcessUpdatedColumnName()} = static::getProcessId();
+            $model->{static::getProcessCreatedColumnName()} = ProcessStamp::getCurrentProcessId();
+            $model->{static::getProcessUpdatedColumnName()} = ProcessStamp::getCurrentProcessId();
         });
 
         static::updating(function ($model) {
-            $model->{static::getProcessUpdatedColumnName()} = static::getProcessId();
+            $model->{static::getProcessUpdatedColumnName()} = ProcessStamp::getCurrentProcessId();
         });
     }
 
@@ -52,49 +52,5 @@ trait ProcessStampable
     public function processUpdated() : ?BelongsTo
     {
         return $this->belongsTo(ProcessStamp::class, static::getProcessUpdatedColumnName());
-    }
-
-    /**
-     * Get a readable process name and type.
-     *
-     * @return array
-     */
-    public static function getProcessName() : array
-    {
-        if (isset($_SERVER['REQUEST_URI'])) {
-            $type = 'url';
-            $name = $_SERVER['REQUEST_URI'];
-        } elseif (isset($_SERVER['SCRIPT_NAME'])) {
-            if ($_SERVER['SCRIPT_NAME'] === 'artisan') {
-                $type = 'artisan';
-                $name = 'artisan '.implode(' ', array_slice($_SERVER['argv'], 1));
-            } else {
-                $type = 'file';
-                $name = $_SERVER['SCRIPT_NAME'];
-            }
-        } else {
-            $type = 'cmd';
-            $name = isset($_SERVER['argv'][0]) ? $_SERVER['argv'][0] : $GLOBALS['argv'][0];
-        }
-
-        return compact('type', 'name');
-    }
-
-    /**
-     * @return int
-     */
-    public static function getProcessId() : int
-    {
-        $process = static::getProcessName();
-        $hash = ProcessStamp::makeProcessHash($process);
-
-        if (config('process-stamp.cache.enabled')) {
-            return Cache::store(config('process-stamp.cache.store'))
-                        ->forever($hash, function () use ($process, $hash) {
-                            return ProcessStamp::firstOrCreateByProcess($process, $hash)->getKey();
-                        });
-        }
-
-        return ProcessStamp::firstOrCreateByProcess($process, $hash)->getKey();
     }
 }

--- a/tests/Fakes/migrations/2019_04_03_101010_add_posts_table.php
+++ b/tests/Fakes/migrations/2019_04_03_101010_add_posts_table.php
@@ -15,8 +15,9 @@ class AddPostsTable extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('title');
+            $table->string('name');
             $table->processIds();
+            $table->timestamps();
         });
     }
 

--- a/tests/ParentTest.php
+++ b/tests/ParentTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace OrisIntel\ProcessStamps\Tests;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use OrisIntel\ProcessStamps\ProcessStamp;
+use OrisIntel\ProcessStamps\Tests\Fakes\Post;
+
+class ParentTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function createPost() : Post
+    {
+        return Post::create(['name' => 'Test 123']);
+    }
+
+    /** @test */
+    public function url_simple()
+    {
+        $process = ProcessStamp::getProcessName('url', '/test/hello');
+
+        $this->assertEquals('/test/hello', $process['name']);
+        $this->assertEquals('/test', $process['parent_name']);
+    }
+
+    /** @test */
+    public function url_simple_with_extension()
+    {
+        $process = ProcessStamp::getProcessName('url', '/test/hello.php');
+
+        $this->assertEquals('/test/hello.php', $process['name']);
+        $this->assertEquals('/test', $process['parent_name']);
+    }
+
+    /** @test */
+    public function url_simple_with_query_string()
+    {
+        $process = ProcessStamp::getProcessName('url', '/test/hello?test=1234&another=true');
+
+        $this->assertEquals('/test/hello?test=1234&another=true', $process['name']);
+        $this->assertEquals('/test/hello', $process['parent_name']);
+    }
+
+    /** @test */
+    public function saved_model_includes_parent()
+    {
+        // Set the url so process stamps can detect it
+        $_SERVER['REQUEST_URI'] = '/test/hello?test=1234&another=true';
+        $model = $this->createPost();
+
+        $this->assertEquals('/test/hello?test=1234&another=true', $model->processCreated->name);
+        $this->assertEquals('/test/hello', $model->processCreated->parent->name);
+        $this->assertEquals('/test', $model->processCreated->parent->parent->name);
+    }
+}

--- a/tests/ParentTest.php
+++ b/tests/ParentTest.php
@@ -53,6 +53,7 @@ class ParentTest extends TestCase
 
         $this->assertEquals('/test/hello?test=1234&another=true', $model->processCreated->name);
         $this->assertEquals('/test/hello', $model->processCreated->parent->name);
+        $this->assertEquals(1, $model->processCreated->parent->children()->count());
         $this->assertEquals('/test', $model->processCreated->parent->parent->name);
         $this->assertCount(3, ProcessStamp::all());
     }

--- a/tests/ParentTest.php
+++ b/tests/ParentTest.php
@@ -45,6 +45,8 @@ class ParentTest extends TestCase
     /** @test */
     public function saved_model_includes_parent()
     {
+        $this->assertCount(0, ProcessStamp::all());
+
         // Set the url so process stamps can detect it
         $_SERVER['REQUEST_URI'] = '/test/hello?test=1234&another=true';
         $model = $this->createPost();
@@ -52,5 +54,32 @@ class ParentTest extends TestCase
         $this->assertEquals('/test/hello?test=1234&another=true', $model->processCreated->name);
         $this->assertEquals('/test/hello', $model->processCreated->parent->name);
         $this->assertEquals('/test', $model->processCreated->parent->parent->name);
+        $this->assertCount(3, ProcessStamp::all());
+    }
+
+    /** @test */
+    public function artisan_simple()
+    {
+        $process = ProcessStamp::getProcessName('artisan', 'test:sync');
+
+        $this->assertEquals('artisan test:sync', $process['name']);
+    }
+
+    /** @test */
+    public function artisan_with_flags()
+    {
+        $process = ProcessStamp::getProcessName('artisan', 'test:sync --help');
+
+        $this->assertEquals('artisan test:sync --help', $process['name']);
+        $this->assertEquals('artisan test:sync', $process['parent_name']);
+    }
+
+    /** @test */
+    public function artisan_with_options()
+    {
+        $process = ProcessStamp::getProcessName('artisan', 'test:sync --url_id=12345 --limit=4');
+
+        $this->assertEquals('artisan test:sync --url_id=12345 --limit=4', $process['name']);
+        $this->assertEquals('artisan test:sync', $process['parent_name']);
     }
 }

--- a/tests/ProcessStampModelTest.php
+++ b/tests/ProcessStampModelTest.php
@@ -37,7 +37,7 @@ class ProcessStampModelTest extends TestCase
     }
 
     /** @test */
-    public function existing_process_id_entry_can_be_retreived()
+    public function existing_process_id_entry_can_be_retrieved()
     {
         $process = [
             'type' => 'artisan',

--- a/tests/ProcessStampModelTest.php
+++ b/tests/ProcessStampModelTest.php
@@ -29,11 +29,14 @@ class ProcessStampModelTest extends TestCase
             'name' => 'db:seed',
         ];
 
-        $model = ProcessStamp::firstOrCreateByProcess($process);
+        $stamp = ProcessStamp::firstOrCreateByProcess($process);
 
-        $this->assertInstanceOf(ProcessStamp::class, $model);
-        $this->assertEquals('artisan', $model->type);
-        $this->assertEquals('db:seed', $model->name);
+        $this->assertInstanceOf(ProcessStamp::class, $stamp);
+        $this->assertEquals('artisan', $stamp->type);
+        $this->assertEquals('db:seed', $stamp->name);
+        $this->assertNotNull($stamp->hash);
+        $this->assertNull($stamp->parent);
+        $this->assertTrue($stamp->children->isEmpty());
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,11 +29,4 @@ abstract class TestCase extends Orchestra
             ProcessStampsServiceProvider::class,
         ];
     }
-
-    /**
-     * @param \Illuminate\Foundation\Application $app
-     */
-    protected function getEnvironmentSetUp($app)
-    {
-    }
 }


### PR DESCRIPTION
Creates the ability to have parent / child process ids. 

Example:
The parent of `php artisan post:refresh --post-id=134` would be `php artisan post:refresh`. This allows you to correlate multiple items with similar base commands (but different params) together.