### PR TITLE
Fix races during process row creation using Laravel's upsert.

### DIFF
--- a/src/ProcessStamp.php
+++ b/src/ProcessStamp.php
@@ -59,21 +59,21 @@ class ProcessStamp extends Model
             $parent = static::firstOrCreateByProcess(static::getProcessName($process['type'], $process['parent_name']));
         }
 
-        $stamp = static::where('hash', $hash)->first();
-
-        /*
-         * If stamp does not exist in the database yet, go ahead and obtain a lock to create it.
-         * This specifically doesn't lock as the first step to avoid all calls obtaining a lock from the cache if the item already exists in the DB.
-         */
-        if (! $stamp) {
-            Cache::lock('process-stamps-hash-create-' . $hash, 10)->get(function () use (&$stamp, $hash, $process, $parent) {
-                $stamp = static::firstOrCreate(['hash' => $hash], [
+        // Workaround races with `firstOrCreate` by leveraging a no-change upsert.
+        // NOTE: Not using `insertOrIgnore` because of possible side-effects.
+        static::upsert(
+            [
+                [
+                    'hash'      => $hash,
                     'name'      => trim($process['name']),
                     'type'      => $process['type'],
                     'parent_id' => optional($parent)->getKey(),
-                ]);
-            });
-        }
+                ],
+            ],
+            ['hash'], // Should be unique to hash.
+            [] // Update nothing.
+        );
+        $stamp = static::where('hash', $hash)->first();
 
         return $stamp;
     }


### PR DESCRIPTION
This attempts to address a race issue with the cache locks by using Laravel's upsert function