### PR TITLE
Updated stamp creation to leverage the retry helper method

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: tests
 
 on:
     push:
+    pull_request:
     schedule:
         - cron: '0 0 * * *'
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Laravel Process Stamps
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/orisintel/laravel-process-stamps.svg?style=flat-square)](https://packagist.org/packages/orisintel/laravel-process-stamps)
-[![Build Status](https://img.shields.io/github/workflow/status/orisintel/laravel-process-stamps/tests?style=flat-square)](https://github.com/orisintel/laravel-process-stamps/actions?query=workflow%3Atests)
-[![Total Downloads](https://img.shields.io/packagist/dt/orisintel/laravel-process-stamps.svg?style=flat-square)](https://packagist.org/packages/orisintel/laravel-process-stamps)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/always-open/laravel-process-stamps.svg?style=flat-square)](https://packagist.org/packages/always-open/laravel-process-stamps)
+[![Build Status](https://img.shields.io/github/workflow/status/always-open/laravel-process-stamps/tests?style=flat-square)](https://github.com/always-open/laravel-process-stamps/actions?query=workflow%3Atests)
+[![Total Downloads](https://img.shields.io/packagist/dt/always-open/laravel-process-stamps.svg?style=flat-square)](https://packagist.org/packages/always-open/laravel-process-stamps)
 
 It is sometimes very useful to know which process created or modified a particular record in your database. This package provides a trait to add to your Laravel models which automatically logs that for you.
 
@@ -11,13 +11,13 @@ It is sometimes very useful to know which process created or modified a particul
 You can install the package via composer:
 
 ```bash
-composer require orisintel/laravel-process-stamps
+composer require always-open/laravel-process-stamps
 ```
 
 ## Configuration
 
 ``` php
-php artisan vendor:publish --provider="\OrisIntel\ProcessStamps\ProcessStampsServiceProvider"
+php artisan vendor:publish --provider="\AlwaysOpen\ProcessStamps\ProcessStampsServiceProvider"
 ```
 
 Running the above command will publish both the migration and the config file.
@@ -84,7 +84,7 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ### Security
 
-If you discover any security related issues, please email [opensource@orisintel.com](mailto:opensource@orisintel.com) instead of using the issue tracker.
+If you discover any security related issues, please email @tomschlick or @qschmick directly instead of using the issue tracker.
 
 ## Credits
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,4 @@
 
 ## Reporting a Vulnerability
 
-If you encounter what you believe to be a security vulnerability, please report it immediately to opensource@orisintel.com. Please include your name, your email address, the url of the package, and a description of the suspected issue. 
+If you encounter what you believe to be a security vulnerability, please report it immediately to @tomschlick or @qschmick. Please include your name, your email address, the url of the package, and a description of the suspected issue. 

--- a/composer.json
+++ b/composer.json
@@ -1,27 +1,14 @@
 {
-    "name": "orisintel/laravel-process-stamps",
+    "name": "always-open/laravel-process-stamps",
     "description": "Logs which process created or modified a record",
     "keywords": [
-        "orisintel",
+        "always-open",
         "laravel-process-stamps",
         "laravel",
         "logging"
     ],
-    "homepage": "https://github.com/orisintel/laravel-process-stamps",
+    "homepage": "https://github.com/always-open/laravel-process-stamps",
     "license": "MIT",
-    "authors": [
-        {
-            "name": "Tom Schlick",
-            "email": "tschlick@orisintel.com",
-            "role": "Developer"
-        },
-        {
-            "name": "ORIS Intelligence",
-            "email": "developers@orisintel.com",
-            "homepage": "https://orisintel.com",
-            "role": "Organization"
-        }
-    ],
     "require": {
         "php": "^7.3|^8.0",
         "laravel/framework": "^8.0"
@@ -35,12 +22,12 @@
     },
     "autoload": {
         "psr-4": {
-            "OrisIntel\\ProcessStamps\\": "src"
+            "AlwaysOpen\\ProcessStamps\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "OrisIntel\\ProcessStamps\\Tests\\": "tests"
+            "AlwaysOpen\\ProcessStamps\\Tests\\": "tests"
         }
     },
     "scripts": {
@@ -54,7 +41,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "OrisIntel\\ProcessStamps\\ProcessStampsServiceProvider"
+                "AlwaysOpen\\ProcessStamps\\ProcessStampsServiceProvider"
             ]
         }
     }

--- a/src/ProcessStamp.php
+++ b/src/ProcessStamp.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OrisIntel\ProcessStamps;
+namespace AlwaysOpen\ProcessStamps;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;

--- a/src/ProcessStamp.php
+++ b/src/ProcessStamp.php
@@ -3,10 +3,10 @@
 namespace OrisIntel\ProcessStamps;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\DB;
 
 class ProcessStamp extends Model
 {
@@ -42,6 +42,8 @@ class ProcessStamp extends Model
      * @param null|string $hash
      *
      * @return ProcessStamp
+     *
+     * @throws ModelNotFoundException
      */
     public static function firstOrCreateByProcess(array $process, ?string $hash = null) : self
     {
@@ -59,23 +61,31 @@ class ProcessStamp extends Model
             $parent = static::firstOrCreateByProcess(static::getProcessName($process['type'], $process['parent_name']));
         }
 
-        $stamp = static::where('hash', $hash)->first();
+        return retry(4, function() use ($hash, $process, $parent) {
+            $stamp = static::firstWhere('hash', $hash);
 
-        /*
-         * If stamp does not exist in the database yet, go ahead and obtain a lock to create it.
-         * This specifically doesn't lock as the first step to avoid all calls obtaining a lock from the cache if the item already exists in the DB.
-         */
-        if (! $stamp) {
-            Cache::lock('process-stamps-hash-create-' . $hash, 10)->get(function () use (&$stamp, $hash, $process, $parent) {
-                $stamp = static::firstOrCreate(['hash' => $hash], [
-                    'name'      => trim($process['name']),
-                    'type'      => $process['type'],
-                    'parent_id' => optional($parent)->getKey(),
-                ]);
-            });
-        }
+            /*
+             * If stamp does not exist in the database yet, go ahead and obtain a lock to create it.
+             * This specifically doesn't lock as the first step to avoid all calls obtaining a lock from the cache if
+             * the item already exists in the DB.
+             */
+            if (! $stamp) {
+                Cache::lock('process-stamps-hash-create-' . $hash, 10)
+                    ->get(function () use (&$stamp, $hash, $process, $parent) {
+                        $stamp = static::firstOrCreate(['hash' => $hash], [
+                            'name'      => trim($process['name']),
+                            'type'      => $process['type'],
+                            'parent_id' => optional($parent)->getKey(),
+                        ]);
+                    });
+            }
 
-        return $stamp;
+            if (null === $stamp) {
+                throw new ModelNotFoundException();
+            }
+
+            return $stamp;
+        }, 25);
     }
 
     /**

--- a/src/ProcessStampable.php
+++ b/src/ProcessStampable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OrisIntel\ProcessStamps;
+namespace AlwaysOpen\ProcessStamps;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 

--- a/src/ProcessStampsServiceProvider.php
+++ b/src/ProcessStampsServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OrisIntel\ProcessStamps;
+namespace AlwaysOpen\ProcessStamps;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Arr;

--- a/tests/Fakes/Post.php
+++ b/tests/Fakes/Post.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OrisIntel\ProcessStamps\Tests\Fakes;
+namespace AlwaysOpen\ProcessStamps\Tests\Fakes;
 
 use Illuminate\Database\Eloquent\Model;
-use OrisIntel\ProcessStamps\ProcessStampable;
+use AlwaysOpen\ProcessStamps\ProcessStampable;
 
 class Post extends Model
 {

--- a/tests/ParentTest.php
+++ b/tests/ParentTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace OrisIntel\ProcessStamps\Tests;
+namespace AlwaysOpen\ProcessStamps\Tests;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use OrisIntel\ProcessStamps\ProcessStamp;
-use OrisIntel\ProcessStamps\Tests\Fakes\Post;
+use AlwaysOpen\ProcessStamps\ProcessStamp;
+use AlwaysOpen\ProcessStamps\Tests\Fakes\Post;
 
 class ParentTest extends TestCase
 {

--- a/tests/ProcessStampModelTest.php
+++ b/tests/ProcessStampModelTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OrisIntel\ProcessStamps\Tests;
+namespace AlwaysOpen\ProcessStamps\Tests;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use OrisIntel\ProcessStamps\ProcessStamp;
+use AlwaysOpen\ProcessStamps\ProcessStamp;
 
 class ProcessStampModelTest extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace OrisIntel\ProcessStamps\Tests;
+namespace AlwaysOpen\ProcessStamps\Tests;
 
 use Orchestra\Testbench\TestCase as Orchestra;
-use OrisIntel\ProcessStamps\ProcessStampsServiceProvider;
+use AlwaysOpen\ProcessStamps\ProcessStampsServiceProvider;
 
 abstract class TestCase extends Orchestra
 {


### PR DESCRIPTION
### Issue
When multiple requests happen (AJAX Async processing) and they will all have the same process hash the first request will work, some subset of following requests will fail, then the rest will work. This happens because if the hash doesn't already exist we block via a cache lock. This then returns a null instance for the subsequent requests until the record is created.

### Solution
Updated the firstOrCreate method to use the retry helper. Now when a null instance would be returned instead we'll throw an exception and retry both finding the instances in the DB and checking on the Cache::lock.

I tried to set sane starting values (25ms sleep and 4 total retries) which should be well enough for most instances to create a single DB records (100ms total)

### Release notes
Better handling of stamp creation to support high concurrency